### PR TITLE
Fix linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,5 +38,5 @@ src/%.o: src/%.c
 # Specific programs
 lan951x-led-ctl:	src/lan951x-led-ctl.o
 	@$(ECHO) "\t==> Linking objects to output file $@"
-	@$(CC) $(CFLAGS) $(LDFLAGS) $+ -o $@
+	$(CC) $(CFLAGS) $+ $(LDFLAGS) -o $@
 	@$(STRIP) $@


### PR DESCRIPTION
The library should come after the object file, to ensure that the dependency resolution works correctly.
Without this patch, the tool would fail to build on my system (AArch64 Ubuntu 20.10).